### PR TITLE
Fixed typo

### DIFF
--- a/api.js
+++ b/api.js
@@ -245,8 +245,7 @@ const endpoints = {
 				username: {
 					help: "The author username",
 					example: "lilyachty",
-					required: false,
-					required: true
+					required: false
 				},
 				download: {
 					help: "Set this to `1` to get a mp4 file",


### PR DESCRIPTION
Removed redundant "required" field entry for public endpoint `/public/video` username param.

Should fix error thrown leaving "Author username" message when calling the endpoint without the username param.